### PR TITLE
Improve clarity of readme; fix var name in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ In more detail:
 
 * The **raw score** is the sum of all of the question choice scores for that creative quality, for an individual survey response.
   * **Example:** If I select four question choices that impact the **Purpose** quality with the scores 3, 3, 2, and -1, then my raw score for Purpose would be `3 + 3 + 2 - 1 = 7`.
-* The **max score** is the highest possible score a respondent could've gotten for a quality, if they answer all the questions _(ie: if you answered by choosing the highest value choice per question that is linked to that quality)_. It is static, because if you skip a question, we don't increase the max.
-  * **Example:** If you answered 6 questions with choices that are linked to **Purpose**, then the maximum score would be the sum of all the highest scoring choices linked to Purpose for those questions. For example, if the maximum scores were: 2, 1, 4, 3, 2, 3, then the max would be `2 + 1 + 4 + 3 + 2 + 3 = 15`
+* The **max score** is the highest possible score a respondent could've gotten for a quality, if they were to answer all the questions _(ie: if you answered by choosing the highest value choice per question that is linked to that quality)_. It is a static value for everyone, because any could _potentially_ answer all of the questions.
 
 Please update the survey response page to show the raw and max for each quality.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In more detail:
 
 * The **raw score** is the sum of all of the question choice scores for that creative quality, for an individual survey response.
   * **Example:** If I select four question choices that impact the **Purpose** quality with the scores 3, 3, 2, and -1, then my raw score for Purpose would be `3 + 3 + 2 - 1 = 7`.
-* The **max score** is the highest possible score a respondent could've gotten for a quality, if they were to answer all the questions. It is a static value for everyone, because any could _potentially_ answer all of the questions. A question could have multiple choices that link to the same quality (it does in our production survey), so please use the constraint that someone could only choose one choice per question when calculating the max.
+* The **max score** is the highest possible score a respondent could've gotten for a quality, if they were to answer all the questions. It is a static value for everyone, because anyone could _potentially_ answer all of the questions. A question could have multiple choices that link to the same quality (it does in our production survey), so please use the constraint that someone could only choose one choice per question when calculating the max.
 
 Please update the survey response page to show the raw and max for each quality.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In more detail:
 
 * The **raw score** is the sum of all of the question choice scores for that creative quality, for an individual survey response.
   * **Example:** If I select four question choices that impact the **Purpose** quality with the scores 3, 3, 2, and -1, then my raw score for Purpose would be `3 + 3 + 2 - 1 = 7`.
-* The **max score** is the highest possible score a respondent could've gotten for a quality, if they were to answer all the questions _(ie: if you answered by choosing the highest value choice per question that is linked to that quality)_. It is a static value for everyone, because any could _potentially_ answer all of the questions.
+* The **max score** is the highest possible score a respondent could've gotten for a quality, if they were to answer all the questions. It is a static value for everyone, because any could _potentially_ answer all of the questions. A question could have multiple choices that link to the same quality (it does in our production survey), so please use the constraint that someone could only choose one choice per question when calculating the max.
 
 Please update the survey response page to show the raw and max for each quality.
 

--- a/app/views/survey_responses/show.html.erb
+++ b/app/views/survey_responses/show.html.erb
@@ -18,14 +18,14 @@
 
     <hr>
 
-    <% @survey_response.answers.each do |question_response| %>
-      <%= render 'questions/header', question: question_response.question %>
+    <% @survey_response.answers.each do |answer| %>
+      <%= render 'questions/header', question: answer.question %>
 
       <table class="table table-bordered">
-        <% question_response.question.question_choices.each do |question_choice| %>
+        <% answer.question.question_choices.each do |question_choice| %>
           <tr>
             <td>
-              <% if question_choice == question_response.question_choice %>
+              <% if question_choice == answer.question_choice %>
                 <strong>
                   <%= question_choice.text %>
                 </strong>


### PR DESCRIPTION
- Improves the clarity of the readme around max score
- Renames variable in `responses#show` view that had been missed when previously changing QuestionResponse --> Answer.